### PR TITLE
Two minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Version 0.4.0 - 2011-07-04
 ### New features 
 
   - Hierarchical BlockFormat
-  - Block manipulations (attach and dettach)  
+  - Block manipulations (attach and detach)
 
 ### Code quality 
 

--- a/src/Configuration.scala
+++ b/src/Configuration.scala
@@ -132,11 +132,11 @@ case class Configuration( data: Map[String,String] ) {
    *  The initial configuration is not modified. The prefix is removed in the
    *  resulting configuration. An important property:
    *
-   *  <pre>val c2 = c1.attach(prefix, c1.dettach( prefix )</pre>
+   *  <pre>val c2 = c1.attach(prefix, c1.detach( prefix )</pre>
    *
    *  The resulting configuration c2 should be equal to c1.
    */
-  def dettach( prefix: String ) = {
+  def detach( prefix: String ) = {
     require( 
       prefix.substring( prefix.length-1) != ".", 
       "Prefix should not end with a dot"

--- a/test/ConfigurationSpec.scala
+++ b/test/ConfigurationSpec.scala
@@ -124,11 +124,11 @@ class ConfigurationSpec extends FlatSpec with ShouldMatchers with DefaultConvert
     config5[String]("nums.five") should be ("V")
   }
 
-  it can "be dettach from a configuration" in {
+  it can "be detach from a configuration" in {
     val data2 = Map( "one" -> "1", "two" -> "2" )
     val config2 = Configuration( data2 )
     val config3 = config attach ("nums", config2 )
-    val config4 = config3 dettach ("nums")
+    val config4 = config3 detach ("nums")
     config4 should be (config2)
   }
 

--- a/test/ConfigurationSpec.scala
+++ b/test/ConfigurationSpec.scala
@@ -180,8 +180,7 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
     config.get[String]("baz") should be (Some("hello world"))
   }
 
-  it can "be loaded from a file" in {
-    val filename = "/tmp/configrity_configuration_obj_spec.conf"
+  it can "be loaded from a file" in {    
     val fmt = FlatFormat
     val s = 
       """
@@ -189,7 +188,7 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
       bar = 2
       baz = "hello world"
       """
-    autoFile( filename, s ){ file =>
+    autoFile( s ){ file =>
       val fn = file.getAbsolutePath
       val config = Configuration.load(fn,fmt)
       config.get[Boolean]("foo") should be (Some(true))

--- a/test/io/BlockFormatSpec.scala
+++ b/test/io/BlockFormatSpec.scala
@@ -214,16 +214,16 @@ class BlockFormatParserSpec extends StandardParserSpec with IOHelper {
       }
     """
     val childContent = """
-      include "/tmp/parent.conf"
+      include "%s"
       
       block {
         foo = false
         baz = "hello"
       }
     """
-    autoFile( "/tmp/parent.conf", parentContent ) { parent =>
-      autoFile( "/tmp/child.conf", childContent ) { child =>
-        val config = Configuration.load("/tmp/child.conf")
+    autoFile( parentContent ) { parent =>
+      autoFile( childContent.format(parent.getAbsolutePath) ) { child =>
+        val config = Configuration.load(child.getAbsolutePath)
         config[Boolean]("block.foo") should be (false)
         config[Int]("block.bar") should be (2)
         config[String]("block.baz") should be ("hello")
@@ -240,9 +240,9 @@ class BlockFormatParserSpec extends StandardParserSpec with IOHelper {
         baz = "hello"
       }
     """
-    autoFile( "/tmp/child.conf", childContent ) { child =>
+    autoFile( childContent ) { child =>
       intercept[java.io.FileNotFoundException] {
-        val config = Configuration.load("/tmp/child.conf")
+        val config = Configuration.load( child.getAbsolutePath )
       }
     }
   }

--- a/test/io/FlatFormatSpec.scala
+++ b/test/io/FlatFormatSpec.scala
@@ -35,13 +35,13 @@ class FlatFormatParserSpec extends StandardParserSpec with IOHelper{
         bar = 2
     """
     val childContent = """
-      include "/tmp/parent.conf"
+      include "%s"
       foo = false
       baz = "hello"
     """
-    autoFile( "/tmp/parent.conf", parentContent ) { parent =>
-      autoFile( "/tmp/child.conf", childContent ) { child =>
-        val config = Configuration.load("/tmp/child.conf")
+    autoFile( parentContent ) { parent =>
+      autoFile( childContent.format(parent.getAbsolutePath) ) { child =>
+        val config = Configuration.load(child.getAbsolutePath)
         config[Boolean]("foo") should be (false)
         config[Int]("bar") should be (2)
         config[String]("baz") should be ("hello")
@@ -55,9 +55,9 @@ class FlatFormatParserSpec extends StandardParserSpec with IOHelper{
       foo = false
       baz = "hello"
     """
-    autoFile( "/tmp/child.conf", childContent ) { child =>
+    autoFile( childContent ) { child =>
       intercept[java.io.FileNotFoundException] {
-        val config = Configuration.load("/tmp/child.conf")
+        val config = Configuration.load(child.getAbsolutePath)
       }
     }
   }

--- a/test/io/IOHelper.scala
+++ b/test/io/IOHelper.scala
@@ -5,9 +5,9 @@ import java.io.PrintWriter
 
 trait IOHelper {
 
-  def autoFile[A]( filename: String, content: String = "" )
+  def autoFile[A]( content: String = "" )
   ( body: File => A ) = {
-    val f = new File( filename )
+    val f = File.createTempFile("configrity", ".conf")
     try {
       if( content != "" ) {
         val out = new PrintWriter( f )


### PR DESCRIPTION
Hi,
The tests currently fail on Windows as paths like `/tmp/...` are not valid there.
`IOHelper.autoFile` now automatically generates a temporary file.

All tests pass ;)

Cheers,
  Gerolf
