### PR TITLE
Fix issue in Configuration.loadResource

### DIFF
--- a/core/src/Configuration.scala
+++ b/core/src/Configuration.scala
@@ -227,9 +227,11 @@ object Configuration {
    * format can be passed.
    */
   def loadResource( fileName: String, fmt: ImportFormat = defaultFormat ) = {
-    val src = Source.fromInputStream(
-      getClass.getResourceAsStream( fileName ) 
-    )
+    val inputStream = getClass.getResourceAsStream( fileName )
+    if (inputStream == null) {
+      throw new java.io.FileNotFoundException(fileName)
+    }
+    val src = Source.fromInputStream(inputStream)
     load( src, fmt )
   }
 

--- a/core/test/ConfigurationSpec.scala
+++ b/core/test/ConfigurationSpec.scala
@@ -21,7 +21,6 @@ class ConfigurationSpec extends FlatSpec with ShouldMatchers with DefaultConvert
     config.contains("bar") should be (true)
     config.contains("baz") should be (true)
     config.contains("buzz") should be (false)
-    
   }
 
   it should "throw exception if it doesn't contain a key when 'applied'" in {
@@ -219,5 +218,12 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
    config2 should be (config)
  }
 
+ it must "throw FileNotFoundException when loading non-existing resource from the classpath" in {
+   val resName = "/non-existing.conf"
+   val ex = evaluating {
+     Configuration.loadResource( resName )
+   } should produce [java.io.FileNotFoundException]
+   ex.getMessage should be (resName)
+ }
 }
 


### PR DESCRIPTION
Configuration.loadResource("nonExistingFileName") throws NullPointerException from java.io.Reader.

This fixes it to throw FileNotFoundException, which is the same as when using Configuration.load().

See [getResourceAsStream](http://docs.oracle.com/javase/1.4.2/docs/api/java/lang/Class.html#getResourceAsStream%28java.lang.String%29).
