### PR TITLE
Include key in NoSuchElementException message

### DIFF
--- a/core/src/Configuration.scala
+++ b/core/src/Configuration.scala
@@ -43,7 +43,7 @@ case class Configuration( data: Map[String,String] ) {
    * implicitly defined elsewhere.
    */
   def apply[A]( key: String )( implicit converter: ValueConverter[A] ) =
-    get[A](key).getOrElse(throw new NoSuchElementException(key))
+    converter( data get key ) getOrElse ( throw new NoSuchElementException( key ) )
 
   /**
    * Retrieve and convert configuration data in the wanted type. Returns None

--- a/core/src/Configuration.scala
+++ b/core/src/Configuration.scala
@@ -43,7 +43,7 @@ case class Configuration( data: Map[String,String] ) {
    * implicitly defined elsewhere.
    */
   def apply[A]( key: String )( implicit converter: ValueConverter[A] ) =
-    get[A](key).get
+    get[A](key).getOrElse(throw new NoSuchElementException(key))
 
   /**
    * Retrieve and convert configuration data in the wanted type. Returns None

--- a/core/test/ConfigurationSpec.scala
+++ b/core/test/ConfigurationSpec.scala
@@ -26,7 +26,7 @@ class ConfigurationSpec extends FlatSpec with ShouldMatchers with DefaultConvert
   it should "throw exception if it doesn't contain a key when 'applied'" in {
     intercept[java.util.NoSuchElementException] {
       config[Int]("buzz")
-    }
+    }.getMessage should be ("buzz")
   }
 
   it should "be able to return converted values" in {


### PR DESCRIPTION
If a `Configuration` does not contain a key, `Configuration#apply` throws a `NoSuchElementException` with the message "None.get". As this is not very useful for troubleshooting, replace the message with the key in question.
