### PR TITLE
Add 'Configuration#detachAll'

### DIFF
--- a/core/src/Configuration.scala
+++ b/core/src/Configuration.scala
@@ -156,6 +156,19 @@ case class Configuration( data: Map[String,String], prefix: Option[String] ) {
     Configuration( nextData, Some(prefix) )
   }
 
+  /** Detach all values whose keys have a common prefix as a new configuration,
+   *  and repeat this for the entire set of unique prefixes.
+   *
+   *  The initial configuration is not modified. The prefix is removed in the
+   *  resulting configuration.
+   */
+  def detachAll: Map[String, Configuration] = prefixes.map { prefix =>
+    prefix -> detach(prefix)
+  }.toMap
+
+  /** Return the set of unique prefixes in this configuration. */
+  def prefixes = data.keySet.filter( _.contains('.') ).map( _.split('.').head )
+
   /**
    * Adds another configuration values providing entries
    * which are not present in the present one. Useful

--- a/core/test/ConfigurationSpec.scala
+++ b/core/test/ConfigurationSpec.scala
@@ -156,6 +156,16 @@ class ConfigurationSpec extends FlatSpec with ShouldMatchers with DefaultConvert
     full.detach("foo.bar").prefix should be (Some("foo.bar"))
   }
 
+  "Sub configurations" can "be detached from a configuration" in {
+    val sup = Configuration( "foo" -> "bar" )
+    val sub1 = Configuration(Map( "one" -> "1", "two" -> "2" ))
+    val sub2 = Configuration(Map( "first" -> "", "second" -> "b" ))
+    val full = sup attach ("nums", sub1) attach ("letters", sub2)
+    full.detachAll should be (Map(
+      "nums" -> sub1.copy(prefix = Some("nums")),
+      "letters" -> sub2.copy(prefix = Some("letters"))
+    ))
+  }
 }
 
 class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHelper {


### PR DESCRIPTION
For each unique prefix in the configuration, it produces a new configuration containing the values whose keys have the common prefix. It returns a map from prefixes to configurations.

This is useful in the following scenario:

```
accounts {
  alice {
    group: admins
    name:  Alice
  }
  bob {
    group: users
    name:  Bob
  }
}
```

Here the account identifiers, `alice` and `bob`, should obviously not be hard-coded into the application. `Configuration#detachAll` on the `accounts` sub-configuration provides a convenient discovery mechanism for the configured accounts.
