### PR TITLE
Upgrade to Scala 2.10 (at the cost of losing 2.8 compatibility)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -41,8 +41,8 @@ object ConfigrityBuild extends Build {
   lazy val minimalSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.streum",
     version := "0.10.2",
-    scalaVersion := "2.9.2",
-    crossScalaVersions := Seq("2.8.1", "2.8.2", "2.9.0-1", "2.9.1", "2.9.2" )
+    scalaVersion := "2.10.0",
+    crossScalaVersions := Seq("2.9.2", "2.10.0" )
   )
 
   lazy val rootSettings = minimalSettings ++ Seq(
@@ -52,7 +52,7 @@ object ConfigrityBuild extends Build {
 
 
   lazy val standardSettings = minimalSettings ++  Seq(
-    libraryDependencies += "org.scalatest" %% "scalatest" % "1.7.2" % "test",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test",
     scalacOptions ++= Seq( "-deprecation", "-unchecked" ),
     scalaSource in Compile <<= baseDirectory(_ / "src"),
     scalaSource in Test <<= baseDirectory(_ / "test"),


### PR DESCRIPTION
Because of the ScalaTest library dependence, support for older than 2.9.2
version is dropped in this commit, because ScalaTest is not built for older
than Scala 2.9.2.

There would definitely be ways of cross-compiling Configrity for both Scala
2.10, 2.9 and 2.8, as nothing in the code needs to be changed to be compatible
with 2.10.

You might not want to pull this in as-is (because of the lost compatibility),
but it does show that Configrity works just fine with 2.10 and it would be
beneficial to get an artifact published for that as well.
