### PR TITLE
Tweaked Regex to fix Issue #25.

### DIFF
--- a/core/src/io/BlockFormat.scala
+++ b/core/src/io/BlockFormat.scala
@@ -68,6 +68,8 @@ object BlockFormat extends StandardFormat with HierarchyUtils {
         Configuration()
       }
     }
+    
+
 
     def block: Parser[Configuration] = 
       blockStart ~ ( block | emptyBlock | entry ) ~ content ~ closeBrace ^^ {

--- a/core/src/io/StandardFormat.scala
+++ b/core/src/io/StandardFormat.scala
@@ -42,7 +42,8 @@ trait StandardFormat extends Format {
       lst.foldLeft( Configuration() )( _ ++ _ )
 
     def unquote( s: String ) = s.substring( 1, s.size - 1 )
-
+   
+    
     def protect( s: String ) =  word.findFirstIn(s)  match {
       case Some(z) if s == z => s
       case _ => "\"" + s + "\""
@@ -52,18 +53,21 @@ trait StandardFormat extends Format {
     def key = """([^=\s])+""".r 
     val lineSep = "\n"
     def word = """([^=\s\n#\{\}\"\[\],])+""".r 
-    def quoted = """"([^"]*)"""".r /*"*/ ^^ { unquote }
+    def quoted = """"([^"]+)"""".r  // /*"*/ ^^ { unquote }
+    def dequoted = """"([^"]+)"""".r  /*"*/ ^^ { unquote }
+    def emptyQuote = """""""".r  ^^ { unquote }
     val equals  = "="
+      
 
-    def includeDirective = "include" ~ quoted ^^ {
+    def includeDirective = "include" ~ dequoted ^^ {
       case _ ~ filename => Configuration.load( filename )
     }
 
-    def item = word | quoted
-
+    def item = word | quoted | emptyQuote
+    
     def items = repsep( item, "," )
     def list = "[" ~ items ~ "]" ^^ {
-      case _ ~ lst ~ _ => lst.map( protect ).mkString("[ ", ", ", " ]")
+      case _ ~ lst ~ _ => lst.mkString("[ ", ", ", " ]")
     }
 
     def value = item | list

--- a/core/test/ConfigurationSpec.scala
+++ b/core/test/ConfigurationSpec.scala
@@ -85,6 +85,13 @@ class ConfigurationSpec extends FlatSpec with ShouldMatchers with DefaultConvert
     val lst2 = c2[List[String]]( "list" )
     lst should be (lst2)
   }
+  
+  it should "format values containing empty spaces correctly" in {
+    val lst = """"hello world""""
+    val c2 = config.set( "hi", lst )
+    val lst2 = c2[String]( "hi" )
+    lst should be (lst2)
+  }
 
 
   it can "be nicely formatted" in {
@@ -220,7 +227,7 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
     val config = Configuration.parse( s, FlatFormat )
     config.get[Boolean]("foo") should be (Some(true))
     config.get[Int]("bar") should be (Some(2))
-    config.get[String]("baz") should be (Some("hello world"))
+    config.get[String]("baz") should be (Some(""""hello world""""))
   }
 
   it can "be loaded from a file" in {    
@@ -236,7 +243,7 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
       val config = Configuration.load(fn,fmt)
       config.get[Boolean]("foo") should be (Some(true))
       config.get[Int]("bar") should be (Some(2))
-      config.get[String]("baz") should be (Some("hello world"))
+      config.get[String]("baz") should be (Some(""""hello world""""))
       val config2 = Configuration.load(fn)
       config2 should be (config)
     }
@@ -248,7 +255,7 @@ class ConfigurationObjectSpec extends FlatSpec with ShouldMatchers with io.IOHel
    val config = Configuration.loadResource( resName, fmt )
    config.get[Boolean]("foo") should be (Some(true))
    config.get[Int]("bar") should be (Some(2))
-   config.get[String]("baz") should be (Some("hello world"))
+   config.get[String]("baz") should be (Some(""""hello world""""))
    val config2 = Configuration.loadResource( resName )
    config2 should be (config)
  }

--- a/core/test/io/BlockFormatSpec.scala
+++ b/core/test/io/BlockFormatSpec.scala
@@ -102,6 +102,22 @@ class BlockFormatParserSpec extends StandardParserSpec with IOHelper {
     config[String]("block.baz") should be ("x")
     config[String]("block.sub.buzz") should be ("hello")
   }
+  
+  it must "keep parsed double quotes in blocks" in {
+    val s = 
+    """
+     # Example
+    foo = true
+    block {
+      bar = 2 
+      baz = "hello world"
+    }
+    """
+    val config = parse( s ) 
+    config[Boolean]("foo") should be (true)
+    config[Int]("block.bar") should be (2)
+    config[String]("block.baz") should be (""""hello world"""")
+  }
 
   it should "ignore whitespaces" in {
    val s = 
@@ -226,7 +242,7 @@ class BlockFormatParserSpec extends StandardParserSpec with IOHelper {
         val config = Configuration.load(child.getAbsolutePath)
         config[Boolean]("block.foo") should be (false)
         config[Int]("block.bar") should be (2)
-        config[String]("block.baz") should be ("hello")
+        config[String]("block.baz") should be (""""hello"""")
       }
     }
   }

--- a/core/test/io/FlatFormatSpec.scala
+++ b/core/test/io/FlatFormatSpec.scala
@@ -18,7 +18,7 @@ class FlatFormatSpec extends FlatSpec with ShouldMatchers{
     val config = Configuration( 
       Map("foo"->"FOO", "bar"->"1234", 
 	  "baz"->"on",
-          "lst" -> """[ on, on, off, off ]""",
+      "lst" -> """[ on, on, off, off ]""",
 	  "empty" -> ""
 	)
     )
@@ -47,7 +47,7 @@ class FlatFormatParserSpec extends StandardParserSpec with IOHelper{
         val config = Configuration.load(child.getAbsolutePath)
         config[Boolean]("foo") should be (false)
         config[Int]("bar") should be (2)
-        config[String]("baz") should be ("hello")
+        config[String]("baz") should be (""""hello"""")
       }
     }
   }

--- a/core/test/io/StandardParserSpec.scala
+++ b/core/test/io/StandardParserSpec.scala
@@ -35,6 +35,12 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     val config = parse( "    foo=2 " )
     config[Int]("foo") should be (2)
   }
+  
+  it should "keep parsed double quotes" in {
+    val config = parse( """foo= "helloWorld"""")
+    config[String]("foo") should be (""""helloWorld"""")
+  }
+    
 
   it can "parse several lines" in {
     val s = 
@@ -46,7 +52,7 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     val config = parse( s )
     config[Boolean]("foo") should be (true)
     config[Int]("bar") should be (2)
-    config[String]("baz") should be ("hello world")
+    config[String]("baz") should be (""""hello world"""")
   }
 
   it can "parse several badly spaced lines" in {
@@ -59,7 +65,7 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     val config = parse( s )
     config[Boolean]("foo") should be (true)
     config[Int]("bar") should be (2)
-    config[String]("baz") should be ("hello world")
+    config[String]("baz") should be (""""hello world"""")
   }
 
   it must "choke when encoutering an unquoted value with spaces" in {
@@ -180,15 +186,15 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     val config = parse( s ) 
     config[String]("foo") should be ("[ true, false ]")
     config[String]("bar") should be ("[ 1, 2, 3, 4 ]")
-    config[String]("baz") should be ("[ hello, \"wo,rld\" ]")
+    config[String]("baz") should be ("""[ "hello", "wo,rld" ]""")
   }
 
   it can "accept empty strings" in {
     val s =
   """
-    bar = "bar"
+    bar = bar
     foo = ""
-    baz = "baz"
+    baz = baz
   """
     val config = parse( s )
     config[String]("foo") should be ("")
@@ -205,9 +211,9 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     baz = [ "world" ]
     """
     val config = parse( s ) 
-    config[String]("foo") should be ("[ hello ]")
+    config[String]("foo") should be ("""[ "hello" ]""")
     config[String]("bar") should be ("[  ]")
-    config[String]("baz") should be ("[ world ]")
+    config[String]("baz") should be ("""[ "world" ]""")
   }
   
     it can "accept lists defined over several lines" in {
@@ -227,7 +233,7 @@ trait StandardParserSpec extends FlatSpec with ShouldMatchers {
     val config = parse( s ) 
     config[String]("foo") should be ("[ true, false ]")
     config[String]("bar") should be ("[ 1, 2, 3, 4 ]")
-    config[String]("baz") should be ("[ hello, \"wo,rld\" ]")
+    config[String]("baz") should be ("[ \"hello\", \"wo,rld\" ]")
   }
 
 


### PR DESCRIPTION
I have made a few changes to the StandardFormat regex. Most of these changes are updates so that it passes tests. I also added a few in regard to testing values with double quotes.

The test in ConfigurationSpec, "format values containing empty spaces correctly" shows that #25 is closed. I'm not sure that I like having to use quad quotes, to set values that need double quoting. 
