### PR TITLE
cross build for scala 2.11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,7 +40,7 @@ object ConfigrityBuild extends Build {
     licenses := Seq("GNU LesserGPLv3" -> url("http://www.gnu.org/licenses/lgpl.html")),
     homepage := Some(url("https://github.com/paradigmatic/Configrity")),
     scalaVersion := "2.10.2",
-    crossScalaVersions := Seq( "2.9.2", "2.10.2" )
+    crossScalaVersions := Seq( "2.10.2", "2.11.0" )
   )
 
   lazy val rootSettings = minimalSettings ++ Seq(
@@ -50,7 +50,7 @@ object ConfigrityBuild extends Build {
 
 
   lazy val standardSettings = minimalSettings ++  Seq(
-    libraryDependencies +=  "org.scalatest" %% "scalatest" % "1.9.1",
+    libraryDependencies +=  "org.scalatest" %% "scalatest" % "2.1.6",
     scalacOptions <<= scalaVersion map { v: String =>
       val default = Seq( "-deprecation", "-unchecked" )
       if (v.startsWith("2.9.")) default else default ++ Seq( "-feature", "-language:implicitConversions" )


### PR DESCRIPTION
These are the only needed changes for compiling against 2.11.  I dropped the build for 2.9.2 because scalatest 2.1.6 did not cross build against 2.9.2.  If building against 2.9.2 is still desirable, we can add a dependency on `scalaVersion` and select the appropriate version.
